### PR TITLE
Load Button Updates

### DIFF
--- a/MechForge/App.config
+++ b/MechForge/App.config
@@ -5,5 +5,6 @@
     </startup>
     <appSettings>
       <add key="defaultDataDir" value="D:\SteamLibrary\steamapps\common\BATTLETECH\BattleTech_Data\StreamingAssets\data" />
+      <!-- <add key="defaultDataDir" value="D:\GOG Games\BATTLETECH\BattleTech_Data\StreamingAssets\data" />  -->
     </appSettings>
 </configuration>

--- a/MechForge/Controller/TreeViewController.cs
+++ b/MechForge/Controller/TreeViewController.cs
@@ -21,21 +21,28 @@ namespace MechForge.Controller
         private TreeView treeView;
         private IFileNameTranslator fileNameTranslator;
 
-        public DirectoryInfo DirectoryInfo { set { directoryInfo = value; } }
+        public DirectoryInfo DirectoryInfo
+        {
+            set
+            {
+                directoryInfo = value;
+                if ((directoryInfo.Exists) && (this.treeView != null))
+                {
+                    Clear();
+                    Build();
+                }
+            }
+        }
+
         public TreeView TreeView { set { treeView = value; } }
         public FastColoredTextBox Editor { set { editor = value; } }
         public TreeNode SelectedNode { get; set; }
 
         public TreeViewController(DirectoryInfo directoryInfo,TreeView treeView,IFileNameTranslator fileNameTranslator)
         {
-            this.directoryInfo = directoryInfo;
             this.treeView = treeView;
             this.fileNameTranslator = fileNameTranslator;
-
-            if (directoryInfo.Exists)
-            {
-                BuildTree(directoryInfo, treeView.Nodes);
-            }
+            DirectoryInfo = directoryInfo;
         }
 
         public void Build()

--- a/MechForge/Form1.Designer.cs
+++ b/MechForge/Form1.Designer.cs
@@ -52,6 +52,7 @@
             this.toolStripButton1 = new System.Windows.Forms.ToolStripButton();
             this.toolStripButton2 = new System.Windows.Forms.ToolStripButton();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.fastColoredTextBox1)).BeginInit();
             this.EditorTab.SuspendLayout();
             this.CodeTab.SuspendLayout();
@@ -108,7 +109,6 @@
             this.fastColoredTextBox1.CharWidth = 8;
             this.fastColoredTextBox1.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.fastColoredTextBox1.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
-            this.fastColoredTextBox1.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.fastColoredTextBox1.IsReplaceMode = false;
             this.fastColoredTextBox1.Location = new System.Drawing.Point(0, 3);
             this.fastColoredTextBox1.Name = "fastColoredTextBox1";
@@ -182,7 +182,8 @@
             // 
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.saveToolStripMenuItem,
-            this.saveAllToolStripMenuItem});
+            this.saveAllToolStripMenuItem,
+            this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "File";
@@ -190,14 +191,14 @@
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // saveAllToolStripMenuItem
             // 
             this.saveAllToolStripMenuItem.Name = "saveAllToolStripMenuItem";
-            this.saveAllToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+            this.saveAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveAllToolStripMenuItem.Text = "Save all";
             this.saveAllToolStripMenuItem.Click += new System.EventHandler(this.saveAllToolStripMenuItem_Click);
             // 
@@ -307,6 +308,13 @@
             this.panel1.Size = new System.Drawing.Size(1384, 35);
             this.panel1.TabIndex = 14;
             // 
+            // exitToolStripMenuItem
+            // 
+            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exitToolStripMenuItem.Text = "Exit";
+            this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 11F);
@@ -366,6 +374,7 @@
         private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveAllToolStripMenuItem;
         private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
     }
 }
 

--- a/MechForge/Form1.cs
+++ b/MechForge/Form1.cs
@@ -46,9 +46,7 @@ namespace MechForge
 
         private void LoadButton_Click(object sender, EventArgs e)
         {
-            treeViewController.Clear();
             treeViewController.DirectoryInfo = new DirectoryInfo(FolderTextBox.Text);
-            treeViewController.Build();
         }
 
         private void btnSave_Click(object sender, EventArgs e)
@@ -128,6 +126,11 @@ namespace MechForge
             btnSave_Click(sender, e);
         }
 
+        private void exitToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+
         private void setEditorTabModified(bool modified)
         {
             TabPage codeTab = EditorTab.TabPages[EditorTab.TabPages.IndexOf(CodeTab)];
@@ -168,5 +171,6 @@ namespace MechForge
             }
             
         }
+
     }
 }


### PR DESCRIPTION
Use Case:  Paste in GOG path instead of Steam, click Load and it does not load.  Per Trello a directory chooser dialog is backburner, but this is a temporary fix to allow pasting in a path to work.  Clear and Build of treeview now happens in DirectoryInfo setter. Treeview constructor changed.